### PR TITLE
fix: skip branches where author's username cannot be established

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30342,17 +30342,20 @@ function getCommitCommentsForBranch(commitComments, branch) {
 }
 function planBranchAction(now, branch, filters, commitComments, params) {
     return __awaiter(this, void 0, void 0, function* () {
-        var _a;
+        var _a, _b;
         if (branch.author &&
             params.protectedOrganizationName &&
             branch.author.belongsToOrganization) {
             return skip(`author ${branch.author.username} belongs to protected organization ${params.protectedOrganizationName}`);
         }
+        if (!((_a = branch.author) === null || _a === void 0 ? void 0 : _a.username) && !params.ignoreUnknownAuthors) {
+            return skip(`unable to determine username of author for branch ${branch.branchName}`);
+        }
         if (branch.openPrs && params.ignoreBranchesWithOpenPRs) {
             return skip(`branch ${branch.branchName} has open PRs`);
         }
         if (filters.authorsRegex &&
-            ((_a = branch.author) === null || _a === void 0 ? void 0 : _a.username) &&
+            ((_b = branch.author) === null || _b === void 0 ? void 0 : _b.username) &&
             filters.authorsRegex.test(branch.author.username)) {
             return skip(`author ${branch.author.username} is exempted`);
         }
@@ -30407,7 +30410,6 @@ function logActionRunConfiguration(params, staleCutoff, removeCutoff) {
 function removeStaleBranches(octokit, params) {
     return __awaiter(this, void 0, void 0, function* () {
         var _a, e_1, _b, _c;
-        var _d;
         const headers = params.githubToken
             ? {
                 "Content-Type": "application/json",
@@ -30452,17 +30454,11 @@ function removeStaleBranches(octokit, params) {
             skip: "✅",
         };
         try {
-            for (var _e = true, _f = __asyncValues((0, readBranches_1.readBranches)(octokit, headers, repo, params.protectedOrganizationName)), _g; _g = yield _f.next(), _a = _g.done, !_a; _e = true) {
-                _c = _g.value;
-                _e = false;
+            for (var _d = true, _e = __asyncValues((0, readBranches_1.readBranches)(octokit, headers, repo, params.protectedOrganizationName)), _f; _f = yield _e.next(), _a = _f.done, !_a; _d = true) {
+                _c = _f.value;
+                _d = false;
                 const branch = _c;
                 summary.scanned++;
-                if (!((_d = branch.author) === null || _d === void 0 ? void 0 : _d.username) && !params.ignoreUnknownAuthors) {
-                    console.error("🛑 Failed to find author associated with branch " +
-                        branch.branchName +
-                        ". Use ignore-unknown-authors if this is expected.");
-                    throw new Error("Failed to find author for branch " + branch.branchName);
-                }
                 const plan = yield planBranchAction(now.getTime(), branch, filters, commitComments, params);
                 summary[plan.action]++;
                 core.startGroup(`${icons[plan.action]} branch ${branch.branchName}`);
@@ -30484,7 +30480,7 @@ function removeStaleBranches(octokit, params) {
         catch (e_1_1) { e_1 = { error: e_1_1 }; }
         finally {
             try {
-                if (!_e && !_a && (_b = _f.return)) yield _b.call(_f);
+                if (!_d && !_a && (_b = _e.return)) yield _b.call(_e);
             }
             finally { if (e_1) throw e_1.error; }
         }

--- a/src/removeStaleBranches.ts
+++ b/src/removeStaleBranches.ts
@@ -133,6 +133,11 @@ async function planBranchAction(
       `author ${branch.author.username} belongs to protected organization ${params.protectedOrganizationName}`
     );
   }
+  if (!branch.author?.username && !params.ignoreUnknownAuthors) {
+    return skip(
+      `unable to determine username of author for branch ${branch.branchName}`
+    );
+  }
 
   if (branch.openPrs && params.ignoreBranchesWithOpenPRs) {
     return skip(`branch ${branch.branchName} has open PRs`);
@@ -281,15 +286,6 @@ export async function removeStaleBranches(
     params.protectedOrganizationName
   )) {
     summary.scanned++;
-    if (!branch.author?.username && !params.ignoreUnknownAuthors) {
-      console.error(
-        "🛑 Failed to find author associated with branch " +
-          branch.branchName +
-          ". Use ignore-unknown-authors if this is expected."
-      );
-      throw new Error("Failed to find author for branch " + branch.branchName);
-    }
-
     const plan = await planBranchAction(
       now.getTime(),
       branch,


### PR DESCRIPTION
Motivation:
It feels unnecessary to abort the entire process when the branch author's username cannot be established (and `ignore-unknown-authors` isn't set). When running this action in a repo with many branches, it would be preferable to simply move on and ignore/skip these branches.

Modification:
Rather than throwing and aborting the action, use the `skip` plan for these branches.
