### PR TITLE
Correcting `dry_run` recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This can be prevented by removing the comment, or adding new commits to the bran
 
 ## ⚠️💣 CAUTION
 
-Without setting `dry_run: true`, this action will remove branches. Consider setting `dry_run: true` until you are happy with how this action works.
+Without setting `dry_run: true`, this action will remove branches. Consider setting `dry_run: false` until you are happy with how this action works.
 
 You can also restrict this action to a subset of your branches using the `restrict-branches-regex` regular expression.
 


### PR DESCRIPTION
Correct the wrong setting recommendation [HERE](https://github.com/fpicalausa/remove-stale-branches?tab=readme-ov-file#%EF%B8%8F-caution) to `dry_run: false` since that option won't take action on branches and once you are happy with how this action works you can change it to `dry_run: true`