### PR TITLE
Set ignore-branches-with-open-prs to ignore base of a PR as well

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13009,7 +13009,7 @@ module.exports = {
 
 
 const { parseSetCookie } = __nccwpck_require__(8915)
-const { stringify, getHeadersList } = __nccwpck_require__(3834)
+const { stringify } = __nccwpck_require__(3834)
 const { webidl } = __nccwpck_require__(4222)
 const { Headers } = __nccwpck_require__(6349)
 
@@ -13085,14 +13085,13 @@ function getSetCookies (headers) {
 
   webidl.brandCheck(headers, Headers, { strict: false })
 
-  const cookies = getHeadersList(headers).cookies
+  const cookies = headers.getSetCookie()
 
   if (!cookies) {
     return []
   }
 
-  // In older versions of undici, cookies is a list of name:value.
-  return cookies.map((pair) => parseSetCookie(Array.isArray(pair) ? pair[1] : pair))
+  return cookies.map((pair) => parseSetCookie(pair))
 }
 
 /**
@@ -13520,14 +13519,15 @@ module.exports = {
 /***/ }),
 
 /***/ 3834:
-/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+/***/ ((module) => {
 
 "use strict";
 
 
-const assert = __nccwpck_require__(2613)
-const { kHeadersList } = __nccwpck_require__(6443)
-
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
 function isCTLExcludingHtab (value) {
   if (value.length === 0) {
     return false
@@ -13788,31 +13788,13 @@ function stringify (cookie) {
   return out.join('; ')
 }
 
-let kHeadersListNode
-
-function getHeadersList (headers) {
-  if (headers[kHeadersList]) {
-    return headers[kHeadersList]
-  }
-
-  if (!kHeadersListNode) {
-    kHeadersListNode = Object.getOwnPropertySymbols(headers).find(
-      (symbol) => symbol.description === 'headers list'
-    )
-
-    assert(kHeadersListNode, 'Headers cannot be parsed')
-  }
-
-  const headersList = headers[kHeadersListNode]
-  assert(headersList)
-
-  return headersList
-}
-
 module.exports = {
   isCTLExcludingHtab,
-  stringify,
-  getHeadersList
+  validateCookieName,
+  validateCookiePath,
+  validateCookieValue,
+  toIMFDate,
+  stringify
 }
 
 
@@ -17816,6 +17798,7 @@ const {
   isValidHeaderName,
   isValidHeaderValue
 } = __nccwpck_require__(5523)
+const util = __nccwpck_require__(9023)
 const { webidl } = __nccwpck_require__(4222)
 const assert = __nccwpck_require__(2613)
 
@@ -18369,6 +18352,9 @@ Object.defineProperties(Headers.prototype, {
   [Symbol.toStringTag]: {
     value: 'Headers',
     configurable: true
+  },
+  [util.inspect.custom]: {
+    enumerable: false
   }
 })
 
@@ -27545,6 +27531,20 @@ class Pool extends PoolBase {
       ? { ...options.interceptors }
       : undefined
     this[kFactory] = factory
+
+    this.on('connectionError', (origin, targets, error) => {
+      // If a connection error occurs, we remove the client from the pool,
+      // and emit a connectionError event. They will not be re-used.
+      // Fixes https://github.com/nodejs/undici/issues/3895
+      for (const target of targets) {
+        // Do not use kRemoveClient here, as it will close the client,
+        // but the client cannot be closed in this state.
+        const idx = this[kClients].indexOf(target)
+        if (idx !== -1) {
+          this[kClients].splice(idx, 1)
+        }
+      }
+    })
   }
 
   [kGetDispatcher] () {
@@ -30172,6 +30172,13 @@ const GRAPHQL_QUERY = `query ($repo: String!, $owner: String!, $after: String) {
     }
   }
 }`;
+const GRAPHQL_BASE_PR_QUERY = `query ($repo: String!, $owner: String!, $base: String!) {
+  repository(name: $repo, owner: $owner) {
+    pullRequests(first: 1, states: OPEN, baseRefName: $base) {
+      totalCount
+    }
+  }
+}`;
 const GRAPHQL_QUERY_WITH_ORG = `query ($repo: String!, $owner: String!, $organization: String!, $after: String) {
   repository(name: $repo, owner: $owner) {
     id
@@ -30243,6 +30250,9 @@ function readBranches(octokit, headers, repo, organization) {
                         belongsToOrganization: Boolean((_d = (_c = author.user) === null || _c === void 0 ? void 0 : _c.organization) === null || _d === void 0 ? void 0 : _d.id),
                     };
                 }
+                // Check if branch has open PRs as HEAD (source) or BASE (target)
+                const hasOpenPrsAsHead = associatedPullRequests.nodes.length > 0;
+                const { repository: { pullRequests } } = yield __await(octokit.graphql(GRAPHQL_BASE_PR_QUERY, Object.assign(Object.assign({}, repo), { base: name, headers })));
                 yield yield __await({
                     date: Date.parse(authoredDate),
                     branchName: name,
@@ -30250,7 +30260,7 @@ function readBranches(octokit, headers, repo, organization) {
                     commitId: oid,
                     author: branchAuthor,
                     isProtected: refUpdateRule !== null,
-                    openPrs: associatedPullRequests.nodes.length > 0,
+                    openPrs: hasOpenPrsAsHead || pullRequests.totalCount > 0,
                 });
             }
             pagination = pageInfo;


### PR DESCRIPTION
ignore-branches-with-open-prs currently only ignores HEAD of a PR.  This is unintuitive as there can also be base of a PR branches open.

This PR makes ignore-branches-with-open-prs ignore both HEAD and BASE of a PR branches (No PRs lost due to stale branches).