### PR TITLE
Improved query for branch protection rules

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19874,14 +19874,6 @@ const GRAPHQL_QUERY = `query ($repo: String!, $owner: String!, $after: String) {
             }
           }
           prefix
-          ... on Ref {
-            refUpdateRule {
-              allowsDeletions
-            }
-            rules(first: 1) {
-              totalCount
-            }
-          }
           target {
           ... on Commit {
               oid
@@ -19920,14 +19912,6 @@ const GRAPHQL_QUERY_WITH_ORG = `query ($repo: String!, $owner: String!, $organiz
             }
           }
           prefix
-          ... on Ref {
-            refUpdateRule {
-              allowsDeletions
-            }
-            rules(first: 1) {
-              totalCount
-            }
-          }
           target {
           ... on Commit {
               oid
@@ -19952,6 +19936,23 @@ const GRAPHQL_QUERY_WITH_ORG = `query ($repo: String!, $owner: String!, $organiz
     }
   }
 }`;
+async function fetchProtectedBranchNames(octokit, headers, repo) {
+	const protectedBranchNames = /* @__PURE__ */ new Set();
+	const perPage = 100;
+	for (let page = 1;; ++page) {
+		const { data } = await octokit.request("GET /repos/{owner}/{repo}/branches", {
+			owner: repo.owner,
+			repo: repo.repo,
+			protected: true,
+			per_page: perPage,
+			page,
+			headers
+		});
+		for (const branch of data) protectedBranchNames.add(branch.name);
+		if (data.length < perPage) break;
+	}
+	return protectedBranchNames;
+}
 async function* readBranches(octokit, headers, repo, organization) {
 	let pagination = {
 		hasNextPage: true,
@@ -19959,6 +19960,7 @@ async function* readBranches(octokit, headers, repo, organization) {
 		hasPreviousPage: false,
 		startCursor: null
 	};
+	const protectedBranchNames = await fetchProtectedBranchNames(octokit, headers, repo);
 	while (pagination.hasNextPage) {
 		const params = {
 			...repo,
@@ -19969,7 +19971,7 @@ async function* readBranches(octokit, headers, repo, organization) {
 		const { repository: { refs: { edges, pageInfo } } } = await octokit.graphql(organization ? GRAPHQL_QUERY_WITH_ORG : GRAPHQL_QUERY, params);
 		for (let i = 0; i < edges.length; ++i) {
 			const ref = edges[i];
-			const { name, prefix, refUpdateRule, rules, associatedPullRequests } = ref.node;
+			const { name, prefix, associatedPullRequests } = ref.node;
 			const { oid, authoredDate, author } = ref.node.target;
 			let branchAuthor = null;
 			if (author) branchAuthor = {
@@ -19983,7 +19985,7 @@ async function* readBranches(octokit, headers, repo, organization) {
 				prefix,
 				commitId: oid,
 				author: branchAuthor,
-				isProtected: refUpdateRule !== null || rules.totalCount > 0,
+				isProtected: protectedBranchNames.has(name),
 				openPrs: associatedPullRequests.nodes.length > 0
 			};
 		}

--- a/dist/index.js
+++ b/dist/index.js
@@ -19875,8 +19875,8 @@ const GRAPHQL_QUERY = `query ($repo: String!, $owner: String!, $after: String) {
           }
           prefix
           ... on Ref {
-            branchProtectionRule {
-              id
+            refUpdateRule {
+              allowsDeletions
             }
             rules(first: 1) {
               totalCount
@@ -19921,8 +19921,8 @@ const GRAPHQL_QUERY_WITH_ORG = `query ($repo: String!, $owner: String!, $organiz
           }
           prefix
           ... on Ref {
-            branchProtectionRule {
-              id
+            refUpdateRule {
+              allowsDeletions
             }
             rules(first: 1) {
               totalCount
@@ -19969,7 +19969,7 @@ async function* readBranches(octokit, headers, repo, organization) {
 		const { repository: { refs: { edges, pageInfo } } } = await octokit.graphql(organization ? GRAPHQL_QUERY_WITH_ORG : GRAPHQL_QUERY, params);
 		for (let i = 0; i < edges.length; ++i) {
 			const ref = edges[i];
-			const { name, prefix, branchProtectionRule, rules, associatedPullRequests } = ref.node;
+			const { name, prefix, refUpdateRule, rules, associatedPullRequests } = ref.node;
 			const { oid, authoredDate, author } = ref.node.target;
 			let branchAuthor = null;
 			if (author) branchAuthor = {
@@ -19983,7 +19983,7 @@ async function* readBranches(octokit, headers, repo, organization) {
 				prefix,
 				commitId: oid,
 				author: branchAuthor,
-				isProtected: branchProtectionRule !== null || rules.totalCount > 0,
+				isProtected: refUpdateRule !== null || rules.totalCount > 0,
 				openPrs: associatedPullRequests.nodes.length > 0
 			};
 		}

--- a/dist/index.js
+++ b/dist/index.js
@@ -19875,8 +19875,11 @@ const GRAPHQL_QUERY = `query ($repo: String!, $owner: String!, $after: String) {
           }
           prefix
           ... on Ref {
-            refUpdateRule {
-              allowsDeletions
+            branchProtectionRule {
+              id
+            }
+            rules(first: 1) {
+              totalCount
             }
           }
           target {
@@ -19918,8 +19921,11 @@ const GRAPHQL_QUERY_WITH_ORG = `query ($repo: String!, $owner: String!, $organiz
           }
           prefix
           ... on Ref {
-            refUpdateRule {
-              allowsDeletions
+            branchProtectionRule {
+              id
+            }
+            rules(first: 1) {
+              totalCount
             }
           }
           target {
@@ -19963,7 +19969,7 @@ async function* readBranches(octokit, headers, repo, organization) {
 		const { repository: { refs: { edges, pageInfo } } } = await octokit.graphql(organization ? GRAPHQL_QUERY_WITH_ORG : GRAPHQL_QUERY, params);
 		for (let i = 0; i < edges.length; ++i) {
 			const ref = edges[i];
-			const { name, prefix, refUpdateRule, associatedPullRequests } = ref.node;
+			const { name, prefix, branchProtectionRule, rules, associatedPullRequests } = ref.node;
 			const { oid, authoredDate, author } = ref.node.target;
 			let branchAuthor = null;
 			if (author) branchAuthor = {
@@ -19977,7 +19983,7 @@ async function* readBranches(octokit, headers, repo, organization) {
 				prefix,
 				commitId: oid,
 				author: branchAuthor,
-				isProtected: refUpdateRule !== null,
+				isProtected: branchProtectionRule !== null || rules.totalCount > 0,
 				openPrs: associatedPullRequests.nodes.length > 0
 			};
 		}

--- a/src/readBranches.ts
+++ b/src/readBranches.ts
@@ -18,14 +18,6 @@ const GRAPHQL_QUERY = `query ($repo: String!, $owner: String!, $after: String) {
             }
           }
           prefix
-          ... on Ref {
-            refUpdateRule {
-              allowsDeletions
-            }
-            rules(first: 1) {
-              totalCount
-            }
-          }
           target {
           ... on Commit {
               oid
@@ -64,14 +56,6 @@ const GRAPHQL_QUERY_WITH_ORG = `query ($repo: String!, $owner: String!, $organiz
             }
           }
           prefix
-          ... on Ref {
-            refUpdateRule {
-              allowsDeletions
-            }
-            rules(first: 1) {
-              totalCount
-            }
-          }
           target {
           ... on Commit {
               oid
@@ -156,10 +140,6 @@ type Ref = {
     ];
   };
   prefix: string;
-  refUpdateRule: unknown | null;
-  rules: {
-    totalCount: number;
-  };
   target: GitOject;
 };
 
@@ -174,6 +154,39 @@ type Repository = {
   refs: RefConnection;
 };
 
+async function fetchProtectedBranchNames(
+  octokit: Octokit,
+  headers: { [key: string]: string },
+  repo: Repo,
+): Promise<Set<string>> {
+  const protectedBranchNames = new Set<string>();
+  const perPage = 100;
+
+  for (let page = 1; ; ++page) {
+    const { data } = await octokit.request(
+      "GET /repos/{owner}/{repo}/branches",
+      {
+        owner: repo.owner,
+        repo: repo.repo,
+        protected: true,
+        per_page: perPage,
+        page,
+        headers,
+      },
+    );
+
+    for (const branch of data) {
+      protectedBranchNames.add(branch.name);
+    }
+
+    if (data.length < perPage) {
+      break;
+    }
+  }
+
+  return protectedBranchNames;
+}
+
 export async function* readBranches(
   octokit: Octokit,
   headers: { [key: string]: string },
@@ -186,6 +199,12 @@ export async function* readBranches(
     hasPreviousPage: false,
     startCursor: null,
   };
+
+  const protectedBranchNames = await fetchProtectedBranchNames(
+    octokit,
+    headers,
+    repo,
+  );
 
   while (pagination.hasNextPage) {
     const params = {
@@ -206,8 +225,7 @@ export async function* readBranches(
 
     for (let i = 0; i < edges.length; ++i) {
       const ref = edges[i];
-      const { name, prefix, refUpdateRule, rules, associatedPullRequests } =
-        ref.node;
+      const { name, prefix, associatedPullRequests } = ref.node;
 
       const { oid, authoredDate, author } = ref.node.target as GitOject &
         Commit;
@@ -227,7 +245,7 @@ export async function* readBranches(
         prefix,
         commitId: oid,
         author: branchAuthor,
-        isProtected: refUpdateRule !== null || rules.totalCount > 0,
+        isProtected: protectedBranchNames.has(name),
         openPrs: associatedPullRequests.nodes.length > 0,
       };
     }

--- a/src/readBranches.ts
+++ b/src/readBranches.ts
@@ -19,8 +19,8 @@ const GRAPHQL_QUERY = `query ($repo: String!, $owner: String!, $after: String) {
           }
           prefix
           ... on Ref {
-            branchProtectionRule {
-              id
+            refUpdateRule {
+              allowsDeletions
             }
             rules(first: 1) {
               totalCount
@@ -65,8 +65,8 @@ const GRAPHQL_QUERY_WITH_ORG = `query ($repo: String!, $owner: String!, $organiz
           }
           prefix
           ... on Ref {
-            branchProtectionRule {
-              id
+            refUpdateRule {
+              allowsDeletions
             }
             rules(first: 1) {
               totalCount
@@ -156,7 +156,7 @@ type Ref = {
     ];
   };
   prefix: string;
-  branchProtectionRule: unknown | null;
+  refUpdateRule: unknown | null;
   rules: {
     totalCount: number;
   };
@@ -206,13 +206,8 @@ export async function* readBranches(
 
     for (let i = 0; i < edges.length; ++i) {
       const ref = edges[i];
-      const {
-        name,
-        prefix,
-        branchProtectionRule,
-        rules,
-        associatedPullRequests,
-      } = ref.node;
+      const { name, prefix, refUpdateRule, rules, associatedPullRequests } =
+        ref.node;
 
       const { oid, authoredDate, author } = ref.node.target as GitOject &
         Commit;
@@ -232,7 +227,7 @@ export async function* readBranches(
         prefix,
         commitId: oid,
         author: branchAuthor,
-        isProtected: branchProtectionRule !== null || rules.totalCount > 0,
+        isProtected: refUpdateRule !== null || rules.totalCount > 0,
         openPrs: associatedPullRequests.nodes.length > 0,
       };
     }

--- a/src/readBranches.ts
+++ b/src/readBranches.ts
@@ -19,8 +19,11 @@ const GRAPHQL_QUERY = `query ($repo: String!, $owner: String!, $after: String) {
           }
           prefix
           ... on Ref {
-            refUpdateRule {
-              allowsDeletions
+            branchProtectionRule {
+              id
+            }
+            rules(first: 1) {
+              totalCount
             }
           }
           target {
@@ -62,8 +65,11 @@ const GRAPHQL_QUERY_WITH_ORG = `query ($repo: String!, $owner: String!, $organiz
           }
           prefix
           ... on Ref {
-            refUpdateRule {
-              allowsDeletions
+            branchProtectionRule {
+              id
+            }
+            rules(first: 1) {
+              totalCount
             }
           }
           target {
@@ -150,7 +156,10 @@ type Ref = {
     ];
   };
   prefix: string;
-  refUpdateRule: unknown | null;
+  branchProtectionRule: unknown | null;
+  rules: {
+    totalCount: number;
+  };
   target: GitOject;
 };
 
@@ -197,7 +206,13 @@ export async function* readBranches(
 
     for (let i = 0; i < edges.length; ++i) {
       const ref = edges[i];
-      const { name, prefix, refUpdateRule, associatedPullRequests } = ref.node;
+      const {
+        name,
+        prefix,
+        branchProtectionRule,
+        rules,
+        associatedPullRequests,
+      } = ref.node;
 
       const { oid, authoredDate, author } = ref.node.target as GitOject &
         Commit;
@@ -217,7 +232,7 @@ export async function* readBranches(
         prefix,
         commitId: oid,
         author: branchAuthor,
-        isProtected: refUpdateRule !== null,
+        isProtected: branchProtectionRule !== null || rules.totalCount > 0,
         openPrs: associatedPullRequests.nodes.length > 0,
       };
     }


### PR DESCRIPTION
Fixes https://github.com/fpicalausa/remove-stale-branches/issues/35

`refUpdateRule` was scoped to the PAT permissions, viewer or admin-scoped, and would return `null` for admins even on protected branches.
There is another `rules` parameter in graphql to get the newer organization rulesets protections details but it doesn't help for people using the old protection rules.

So instead of complicating it, just use the REST API which has all the details needed and doesn't require admin permissions.